### PR TITLE
Allowed second -k to embed Knot DNS commands in contextual transaction

### DIFF
--- a/dns_zonediff.c
+++ b/dns_zonediff.c
@@ -372,8 +372,9 @@ int do_zonediff(const char* left_zone, const char* right_zone, const char* origi
 		return 1;
 	}
 
-	/* If outputting knotc commands, start a transaction */
-	if (output_knotc_commands)
+	/* If outputting knotc commands and no contextual transation,
+	 * start a transaction for the diff */
+	if (output_knotc_commands == 1)
 	{
 		printf("zone-begin %s\n", zone_name);
 	}
@@ -486,8 +487,9 @@ int do_zonediff(const char* left_zone, const char* right_zone, const char* origi
 	zd_free_zone(&left_zone_ll);
 	zd_free_zone(&right_zone_ll);
 
-	/* If outputting knotc commands, commit the transaction */
-	if (output_knotc_commands)
+	/* If outputting knotc commands and no contextual transaction,
+	 * commit the transaction now */
+	if (output_knotc_commands == 1)
 	{
 		printf("zone-commit %s\n", zone_name);
 	}

--- a/main.c
+++ b/main.c
@@ -46,7 +46,7 @@ void usage(void)
 	printf("Copyright (C) 2018 SURFnet bv\n");
 	printf("All rights reserved (see LICENSE for more information)\n\n");
 	printf("Usage:\n");
-	printf("\tldns-zonediff [-S] [-K] [-N] [-k] [-o <origin>] <left-zone> <right-zone>\n");
+	printf("\tldns-zonediff [-S] [-K] [-N] [-k] [-k] [-o <origin>] <left-zone> <right-zone>\n");
 	printf("\tldns-zonediff -h\n");
 	printf("\n");
 	printf("\tldns-zonediff will output the differences between <left-zone> and\n");
@@ -61,7 +61,7 @@ void usage(void)
 	printf("\t-K   Include DNSKEY records in the comparison\n");
 	printf("\t-N   Include NSEC(3) records in the comparison\n");
 	printf("\t-k   Output knotc commands for insertion/removal\n");
-	printf("\t     of records\n");
+	printf("\t     of records; twice to embed in contextual transaction\n");
 	printf("\n");
 	printf("\t-h   Print this help message\n");
 }
@@ -104,7 +104,8 @@ int main(int argc, char* argv[])
 			include_nsecs = 1;
 			break;
 		case 'k':
-			output_knotc_commands = 1;
+			// May be used twice; second form suppresses zone-begin, -commit
+			output_knotc_commands++;
 			break;
 		case 'o':
 			origin = strdup(optarg);


### PR DESCRIPTION
When invoking ldns-zonediff from within a transaction (which first did `zone-read` and wants the zone not to change after that, say) it is useful to omit the `zone-begin` and `zone-commit` statements in the output of `-k` so this patch allows a second `-k` flag to remove those statements.  It is probably better to make this an explicit choice and allow the transaction to be the default mode of operation (as it will croak and carp if it hits on this problem).  Tested and works.