### PR TITLE
Added option -d to suppress DS from diffs

### DIFF
--- a/dns_zonediff.c
+++ b/dns_zonediff.c
@@ -63,7 +63,7 @@ static uint32_t ldnsplus_rr_get_ttl(ldns_rr *rr)
 }
 
 /* Load a DNS zone from the specified file */
-static int zd_load_zone(const char* zone_file, const char* explicit_origin, char** zone_name, const int include_sigs, const int include_keys, const int include_nsecs, const int output_knotc_commands, dnsz_ll_ent** zone_ll, ldns_rr** soa)
+static int zd_load_zone(const char* zone_file, const char* explicit_origin, char** zone_name, const int include_sigs, const int include_keys, const int include_nsecs, const int include_delegs, const int output_knotc_commands, dnsz_ll_ent** zone_ll, ldns_rr** soa)
 {
 	assert(zone_file != NULL);
 	assert(zone_ll != NULL);
@@ -138,6 +138,7 @@ static int zd_load_zone(const char* zone_file, const char* explicit_origin, char
 
 		if (((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_RRSIG) && !include_sigs) ||
 		    ((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_DNSKEY) && !include_keys) ||
+		    ((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_DS) && !include_delegs) ||
 		    ((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_NSEC) && !include_nsecs) ||
 		    ((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_NSEC3) && !include_nsecs) ||
 		    ((ldns_rr_get_type(cur_rr) == LDNS_RR_TYPE_NSEC3PARAM) && !include_nsecs))
@@ -364,7 +365,7 @@ static void zd_output_rr(const char* zone_name, const ldns_rr* rr, int remove, c
 }
 
 /* Compute the difference between left_zone and right_zone and output to stdout */
-int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int output_knotc_commands, int* diffcount)
+int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int include_delegs, const int output_knotc_commands, int* diffcount)
 {
 	assert(left_zone != NULL);
 	assert(right_zone != NULL);
@@ -379,8 +380,8 @@ int do_zonediff(const char* left_zone, const char* right_zone, const char* origi
 	char*		zone_name	= NULL;
 	int		rv		= 0;
 	
-	if (((rv = zd_load_zone(left_zone, origin, &zone_name, include_sigs, include_keys, include_nsecs, output_knotc_commands, &left_zone_ll, &left_soa)) != 0) ||
-	    ((rv = zd_load_zone(right_zone, origin, NULL, include_sigs, include_keys, include_nsecs, output_knotc_commands, &right_zone_ll, &right_soa)) != 0))
+	if (((rv = zd_load_zone(left_zone, origin, &zone_name, include_sigs, include_keys, include_nsecs, include_delegs, output_knotc_commands, &left_zone_ll, &left_soa)) != 0) ||
+	    ((rv = zd_load_zone(right_zone, origin, NULL, include_sigs, include_keys, include_nsecs, include_delegs, output_knotc_commands, &right_zone_ll, &right_soa)) != 0))
 	{
 		return rv;
 	}

--- a/dns_zonediff.h
+++ b/dns_zonediff.h
@@ -31,7 +31,7 @@
 #ifndef _LDNS_ZONEDIFF_DNS_ZONEDIFF_H
 #define _LDNS_ZONEDIFF_DNS_ZONEDIFF_H
 
-int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int output_knotc_commands, int* diffcount);
+int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int include_delegs, const int output_knotc_commands, int* diffcount);
 
 #endif /* !_LDNS_ZONEDIFF_DNS_ZONEDIFF_H */
  

--- a/dns_zonediff.h
+++ b/dns_zonediff.h
@@ -31,7 +31,7 @@
 #ifndef _LDNS_ZONEDIFF_DNS_ZONEDIFF_H
 #define _LDNS_ZONEDIFF_DNS_ZONEDIFF_H
 
-int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int include_delegs, const int output_knotc_commands, int* diffcount);
+int do_zonediff(const char* left_zone, const char* right_zone, const char* origin, const int include_sigs, const int include_keys, const int include_nsecs, const int include_delegs, const int include_serial, const int output_knotc_commands, int* diffcount);
 
 #endif /* !_LDNS_ZONEDIFF_DNS_ZONEDIFF_H */
  

--- a/main.c
+++ b/main.c
@@ -61,6 +61,7 @@ void usage(void)
 	printf("\t-K   Include DNSKEY records in the comparison\n");
 	printf("\t-N   Include NSEC(3) records in the comparison\n");
 	printf("\t-d   Suppress DS records in the comparison\n");
+	printf("\t-s   Suppress SOA serial number differences\n");
 	printf("\t-k   Output knotc commands for insertion/removal\n");
 	printf("\t     of records; twice to embed in contextual transaction\n");
 	printf("\n");
@@ -88,11 +89,12 @@ int main(int argc, char* argv[])
 	int	include_keys		= 0;
 	int	include_nsecs		= 0;
 	int	include_delegs		= 1;
+	int	include_serial		= 1;
 	int	output_knotc_commands	= 0;
 	int	rv			= 0;
 	int	diffcount		= 0;
 	
-	while ((c = getopt(argc, argv, "-SKNdko:h")) != -1)
+	while ((c = getopt(argc, argv, "-SKNdsko:h")) != -1)
 	{
 		switch(c)
 		{
@@ -107,6 +109,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'd':
 			include_delegs = 0;
+			break;
+		case 's':
+			include_serial = 0;
 			break;
 		case 'k':
 			// May be used twice; second form suppresses zone-begin, -commit
@@ -149,7 +154,7 @@ int main(int argc, char* argv[])
 	}
 
 	/* Perform the comparision */
-	rv = do_zonediff(left_zone, right_zone, origin, include_sigs, include_keys, include_nsecs, include_delegs, output_knotc_commands, &diffcount);
+	rv = do_zonediff(left_zone, right_zone, origin, include_sigs, include_keys, include_nsecs, include_delegs, include_serial, output_knotc_commands, &diffcount);
 
 	cleanup_openssl();
 

--- a/main.c
+++ b/main.c
@@ -46,7 +46,7 @@ void usage(void)
 	printf("Copyright (C) 2018 SURFnet bv\n");
 	printf("All rights reserved (see LICENSE for more information)\n\n");
 	printf("Usage:\n");
-	printf("\tldns-zonediff [-S] [-K] [-N] [-k] [-k] [-o <origin>] <left-zone> <right-zone>\n");
+	printf("\tldns-zonediff [-S] [-K] [-N] [-d] [-k] [-k] [-o <origin>] <left-zone> <right-zone>\n");
 	printf("\tldns-zonediff -h\n");
 	printf("\n");
 	printf("\tldns-zonediff will output the differences between <left-zone> and\n");
@@ -60,6 +60,7 @@ void usage(void)
 	printf("\t-S   Include RRSIG records in the comparison\n");
 	printf("\t-K   Include DNSKEY records in the comparison\n");
 	printf("\t-N   Include NSEC(3) records in the comparison\n");
+	printf("\t-d   Suppress DS records in the comparison\n");
 	printf("\t-k   Output knotc commands for insertion/removal\n");
 	printf("\t     of records; twice to embed in contextual transaction\n");
 	printf("\n");
@@ -86,11 +87,12 @@ int main(int argc, char* argv[])
 	int	include_sigs		= 0;
 	int	include_keys		= 0;
 	int	include_nsecs		= 0;
+	int	include_delegs		= 1;
 	int	output_knotc_commands	= 0;
 	int	rv			= 0;
 	int	diffcount		= 0;
 	
-	while ((c = getopt(argc, argv, "-SKNko:h")) != -1)
+	while ((c = getopt(argc, argv, "-SKNdko:h")) != -1)
 	{
 		switch(c)
 		{
@@ -102,6 +104,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'N':
 			include_nsecs = 1;
+			break;
+		case 'd':
+			include_delegs = 0;
 			break;
 		case 'k':
 			// May be used twice; second form suppresses zone-begin, -commit
@@ -144,7 +149,7 @@ int main(int argc, char* argv[])
 	}
 
 	/* Perform the comparision */
-	rv = do_zonediff(left_zone, right_zone, origin, include_sigs, include_keys, include_nsecs, output_knotc_commands, &diffcount);
+	rv = do_zonediff(left_zone, right_zone, origin, include_sigs, include_keys, include_nsecs, include_delegs, output_knotc_commands, &diffcount);
 
 	cleanup_openssl();
 


### PR DESCRIPTION
This is helpful in situations where DS records are added by
an automatic procedure, and should be ignored as much as
DNSKEY and RRSIG may be ignored.  It is left in by default,
for backward compatibility of the command's operation.